### PR TITLE
Add workflow to lint PRs

### DIFF
--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -1,0 +1,39 @@
+name: Lint PRs
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  
+  cancel_previous:
+    name: Cancel previous runs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+
+  lint_pt:
+    name: Lint PR on upload
+    runs-on: ubuntu-latest
+    needs: cancel_previous
+
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0 # Whole repo history
+
+      - name: Set-up and configure Ruby
+        uses: ruby/setup-ruby@v1.148.0
+        with:
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Run danger
+        env:
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.THORBOT_GITHUB_PACKAGES_ACCESS_TOKEN }}
+        run: |
+          bundle exec danger

--- a/.github/workflows/lint_pr.yml
+++ b/.github/workflows/lint_pr.yml
@@ -34,6 +34,6 @@ jobs:
 
       - name: Run danger
         env:
-          DANGER_GITHUB_API_TOKEN: ${{ secrets.THORBOT_GITHUB_PACKAGES_ACCESS_TOKEN }}
+          DANGER_GITHUB_API_TOKEN: ${{ secrets.THORBOT_GITHUB_API_TOKEN }}
         run: |
           bundle exec danger

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+def check_rubocop
+  rubocop.lint(
+    files: "",
+    inline_comment: true,
+    fail_on_inline_comment: true,
+    report_danger: true,
+    include_cop_names: true,
+  )
+end
+
+check_rubocop

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
-def check_rubocop
-  rubocop.lint(
-    files: "",
-    inline_comment: true,
-    fail_on_inline_comment: true,
-    report_danger: true,
-    include_cop_names: true,
-  )
-end
-
-check_rubocop
+# Run rubocop lint and display errors
+rubocop.lint(
+  files: "",
+  inline_comment: true,
+  fail_on_inline_comment: true,
+  report_danger: true,
+  include_cop_names: true,
+)

--- a/fastlane-plugin-mm_toolkit.gemspec
+++ b/fastlane-plugin-mm_toolkit.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
   spec.add_dependency("redcarpet", ">= 3.5.1")
 
   spec.add_development_dependency("bundler")
+  spec.add_development_dependency("danger")
+  spec.add_development_dependency("danger-rubocop")
   spec.add_development_dependency("fastlane", ">= 2.172.0")
   spec.add_development_dependency("pry")
   spec.add_development_dependency("rake")

--- a/lib/fastlane/plugin/mm_toolkit/actions/download_asset_from_github_release.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/download_asset_from_github_release.rb
@@ -23,7 +23,7 @@ module Fastlane
       #####################################################
 
       def self.download_asset_from_release(api_token, api_bearer, asset_url, destination_path)
-        UI.important("Downloading #{asset_url} to #{destination_path}...")
+        UI.important("Downloading #{asset_url} to #{destination_path}... Extra long line so rubocop complains, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah")
 
         begin
           prepare_destination_path(destination_path)

--- a/lib/fastlane/plugin/mm_toolkit/actions/download_asset_from_github_release.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/download_asset_from_github_release.rb
@@ -23,7 +23,7 @@ module Fastlane
       #####################################################
 
       def self.download_asset_from_release(api_token, api_bearer, asset_url, destination_path)
-        UI.important("Downloading #{asset_url} to #{destination_path}... Extra long line so rubocop complains, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah, blah")
+        UI.important("Downloading #{asset_url} to #{destination_path}...")
 
         begin
           prepare_destination_path(destination_path)


### PR DESCRIPTION
### PR's key points
Simple, the PR adds a Ruby lint to check PRs targeting `master`. It reports errors to the PR via [Danger](https://danger.systems/ruby/).
 
### How to review this PR?
Check the code for correctness, that's it.