### PR TITLE
Remove V from version name

### DIFF
--- a/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
@@ -39,7 +39,7 @@ module Fastlane
           UI.important("HEAD is already tagged as #{head_tag}, no new tag is needed")
         elsif Gem::Version.new(latest_version) < Gem::Version.new(weekly_version)
           new_tag_created = true
-          latest_tag = "v#{weekly_version}"
+          latest_tag = weekly_version
           latest_version = weekly_version
           output_year = week_data[:year].to_i
           output_week_of_year = week_data[:week_of_year].to_i
@@ -71,7 +71,7 @@ module Fastlane
             UI.success("New tag pushed to repo!")
           end
         else
-          latest_tag = "v#{latest_version}"
+          latest_tag = latest_version
           UI.important("No new tag is needed, we are on the correct train 🚂")
         end
 
@@ -116,7 +116,7 @@ module Fastlane
       end
 
       def self.get_version_from_latest_git_tag_from_branch
-        Actions.get_latest_version_from_branch
+        Actions.get_latest_tag_from_branch
       end
 
       def self.get_commit_count_in_head_from_git
@@ -142,7 +142,7 @@ module Fastlane
       def self.details
         "The action generates tags based on the week of the year. The syntax of the generated tags (and the tags the action expect "\
           "as input) is as follows: "\
-          "\nv[two_digit_year].[two_digit_week].0"\
+          "\n[two_digit_year].[two_digit_week].0"\
           "\nThe tag conforms to ISO-8601 standard to calculate weeks between a year: this means that the first week of the year will be "\
           "the one that contains the first Thursday"
       end

--- a/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/app_store_connect_api.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/app_store_connect_api.rb
@@ -3,9 +3,9 @@
 require "httparty"
 require "jwt"
 require "date"
-require_relative "./sales_and_reports_collection"
-require_relative "./reviews"
-require_relative "./customer_reviews"
+require_relative "sales_and_reports_collection"
+require_relative "reviews"
+require_relative "customer_reviews"
 
 class AppStoreConnectAPI
   attr_reader :issuer_id, :key_id, :private_key_content, :vendor_number

--- a/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/customer_reviews.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/customer_reviews.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./review"
+require_relative "review"
 require "json"
 require "date"
 

--- a/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/review.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/review.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require_relative "./review_attributes"
-require_relative "./review_relationships"
+require_relative "review_attributes"
+require_relative "review_relationships"
 
 class Review
   attr_reader :type, :id, :attributes, :relationships

--- a/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/reviews.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/app_store_ax_connector/reviews.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative "./review"
+require_relative "review"
 
 class Reviews
   attr_reader :data, :links, :meta

--- a/lib/fastlane/plugin/mm_toolkit/helper/github_utils_helper.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/github_utils_helper.rb
@@ -6,7 +6,7 @@ module Fastlane
   module Helper
     class GithubUtilsHelper
       GITHUB_BASE_URL = "https://www.github.com"
-      URL_REGEX = /\A#{URI.regexp(['http', 'https'])}\z/
+      URL_REGEX = /\A#{URI.regexp(["http", "https"])}\z/
 
       def self.compose_github_url(url)
         if url =~ URL_REGEX

--- a/lib/fastlane/plugin/mm_toolkit/helper/tag_train_helper.rb
+++ b/lib/fastlane/plugin/mm_toolkit/helper/tag_train_helper.rb
@@ -8,13 +8,5 @@ module Fastlane
     rescue
       nil
     end
-
-    # Returns the latest version from the current branch
-    def self.get_latest_version_from_branch
-      tag = get_latest_tag_from_branch
-      version = tag.gsub(/v/, "")
-
-      version
-    end
   end
 end

--- a/lib/fastlane/plugin/mm_toolkit/version.rb
+++ b/lib/fastlane/plugin/mm_toolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module MmToolkit
-    VERSION = "1.6.0"
+    VERSION = "1.6.1"
   end
 end


### PR DESCRIPTION
### PR's key points
This PR removes the "v" from the version name, not to be included in the app nor in the version tags.

NOTE: For this to work properly on the first try, we should create a tag on the branch with the new format manually. We can remove a nightly tag with the "v" and create it again without it. This way, everything should be working fine.
 
### How to review this PR?
You can run `tag_train` locally with `push_to_repo:false` to test this.