### PR TITLE
Add the option to let git_changelog pick the latest tag in the repo or the latest in the current branch

### DIFF
--- a/lib/fastlane/plugin/mm_toolkit/actions/git_changelog.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/git_changelog.rb
@@ -129,7 +129,7 @@ module Fastlane
           "git describe --abbrev=0 --tags"
         end
 
-        sh(command)
+        sh(command).chomp
       end
 
       #####################################################

--- a/lib/fastlane/plugin/mm_toolkit/version.rb
+++ b/lib/fastlane/plugin/mm_toolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module MmToolkit
-    VERSION = "1.6.1"
+    VERSION = "1.6.2"
   end
 end


### PR DESCRIPTION
### PR's key points
We detected an issue after generating hotfix branches with tags that made the `git_changelog` action generate wrong changelogs, as it was picking the latest git branch from the hotfix branch instead of the current branch (which is the latest tag time-wise but not the latest from the current branch). This is the expected behaviour from the [`last_git_tag` Fastlane action](https://docs.fastlane.tools/actions/last_git_tag/), but for our use cases, it may not result in our desired output.

This PR fixes the issue and lets the user to pass a new parameter, `check_all_repo` to allow using the whole repo history or only the current branch when selecting the starting point to generate the changelog.
 
### How to review this PR?
Check the code, test some tag shenanigans by adding tags to different branches and checking if the action picks the current branch or the whole repo depending on the flag.