### PR TITLE
Add reference_date parameter to tag_train

### DIFF
--- a/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
@@ -170,7 +170,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :committer_name,
             env_name: "FL_TAG_TRAIN_COMMITTER_NAME",
-            description: "Indicates the name of the commiter of the tag",
+            description: "Indicates the name of the committer of the tag",
             type: String,
             optional: true,
             default_value: "tag-train",
@@ -178,7 +178,7 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :committer_email,
             env_name: "FL_TAG_TRAIN_COMMITTER_EMAIL",
-            description: "Indicates the e-mail of the commiter of the tag",
+            description: "Indicates the e-mail of the committer of the tag",
             type: String,
             optional: true,
             default_value: "tag-train@tag-train.com",
@@ -186,10 +186,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(
             key: :reference_date,
             env_name: "FL_TAG_TRAIN_REFERENCE_DATE",
-            description: "Indicates the reference date for the tag in YYYY-MM-DD format. Defaults to today's date",
+            description: "Indicates the reference date for the tag in YYYY-MM-DD format. Defaults to next week's date",
             type: String,
             optional: true,
-            default_value: Time.now.strftime("%F"),
+            default_value: (Time.now + (60 * 60 * 24 * 7)).strftime("%F"),
           )
         ]
       end

--- a/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/tag_train.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'date'
 
 module Fastlane
   module Actions
@@ -18,12 +19,14 @@ module Fastlane
         committer_name = params.fetch(:committer_name)
         committer_email = params.fetch(:committer_email)
         push_to_repo = params.fetch(:push_to_repo)
+        reference_date_string = params.fetch(:reference_date)
+        reference_date = Date.parse(reference_date_string)
 
         UI.message("Reading current tags…")
         latest_version = get_version_from_latest_git_tag_from_branch
         head_tag = get_head_tag_from_git
-        week_data = get_week_data
-        weekly_version = get_weekly_version
+        week_data = get_week_data(reference_date)
+        weekly_version = get_weekly_version(reference_date)
 
         head_already_tagged = false
         new_tag_created = false
@@ -100,17 +103,16 @@ module Fastlane
       # @!group support functions
       #####################################################
 
-      def self.get_week_data
-        date = Date.today
+      def self.get_week_data(reference_date)
         # Using ISO-8601 week-based year and week number.
-        two_digit_year = date.strftime("%g").to_i
-        two_digit_week_of_year = date.strftime("%V").to_i
+        two_digit_year = reference_date.strftime("%g").to_i
+        two_digit_week_of_year = reference_date.strftime("%V").to_i
 
         { year: two_digit_year, week_of_year: two_digit_week_of_year }
       end
 
-      def self.get_weekly_version
-        week_data = get_week_data
+      def self.get_weekly_version(reference_date)
+        week_data = get_week_data(reference_date)
 
         "#{week_data[:year]}.#{week_data[:week_of_year]}.0"
       end
@@ -181,6 +183,14 @@ module Fastlane
             optional: true,
             default_value: "tag-train@tag-train.com",
           ),
+          FastlaneCore::ConfigItem.new(
+            key: :reference_date,
+            env_name: "FL_TAG_TRAIN_REFERENCE_DATE",
+            description: "Indicates the reference date for the tag in YYYY-MM-DD format. Defaults to today's date",
+            type: String,
+            optional: true,
+            default_value: Time.now.strftime("%F"),
+          )
         ]
       end
 

--- a/lib/fastlane/plugin/mm_toolkit/version.rb
+++ b/lib/fastlane/plugin/mm_toolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module MmToolkit
-    VERSION = "1.6.1"
+    VERSION = "1.7.0"
   end
 end


### PR DESCRIPTION
### PR's key points
The PR updates the tag_train action so it receives a `reference_date` to calculate the new tag. This reference date defaults to the current date plus a week so it can generate tags for new weeks by default, but the user can manipulate such date to their tastes.
 
### How to review this PR?
Check the changes, ensure that they make sense