### PR TITLE
Fix api_token usage in tag_train_api

### DIFF
--- a/lib/fastlane/plugin/mm_toolkit/actions/tag_train_api.rb
+++ b/lib/fastlane/plugin/mm_toolkit/actions/tag_train_api.rb
@@ -138,7 +138,7 @@ module Fastlane
 
       def self.gh_get(token, path)
         other_action.github_api(
-          api_token: token,
+          api_bearer: token,
           http_method: "GET",
           path: path,
         )[:json]
@@ -146,7 +146,7 @@ module Fastlane
 
       def self.gh_post(token, path, body)
         other_action.github_api(
-          api_token: token,
+          api_bearer: token,
           http_method: "POST",
           path: path,
           body: body,
@@ -155,7 +155,7 @@ module Fastlane
 
       def self.gh_patch(token, path, body)
         other_action.github_api(
-          api_token: token,
+          api_bearer: token,
           http_method: "PATCH",
           path: path,
           body: body,

--- a/lib/fastlane/plugin/mm_toolkit/version.rb
+++ b/lib/fastlane/plugin/mm_toolkit/version.rb
@@ -2,6 +2,6 @@
 
 module Fastlane
   module MmToolkit
-    VERSION = "1.8.0"
+    VERSION = "1.8.1"
   end
 end


### PR DESCRIPTION
### PR's key points
D'oh... API token and API bearer are not the same for our use case even if documentation may say it...
